### PR TITLE
rebar.config: fix erl_opts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- erlang -*-
 %% Config file for dthread-application
 {deps_dir, ["deps"]}.
-{erl_opts, [debug_info, fail_on_warning]}.
+{erl_opts, [warnings_as_errors]}.
 {sub_dirs, ["src"]}.
 
 {port_env, [


### PR DESCRIPTION
* debug_info is already enabled by default
* fail_on_warning -> warnings_as_errors